### PR TITLE
Fix and improve InputDays, reminder description UX

### DIFF
--- a/frontend/lib/components/inputs/InputDays.svelte
+++ b/frontend/lib/components/inputs/InputDays.svelte
@@ -60,7 +60,8 @@
 <input
   {...attributes}
   bind:value
-  disabled={(!onchange && !onchangemultiple) || initial == undefined}
+  disabled={!onchange && !onchangemultiple}
+  placeholder={placeholder || "1 day"}
   onchange={(ev) => {
     const input = ev.currentTarget;
     const parts = delimiter ? input.value.split(delimiter).filter((v) => !!v) : [input.value];

--- a/frontend/routes/(authed)/settings/Dosage.svelte
+++ b/frontend/routes/(authed)/settings/Dosage.svelte
@@ -172,7 +172,8 @@
   <PreferenceItem name="Reminder Recurrence">
     {#snippet description()}
       How often you want to be reminded to take your medication. This is a list of intervals
-      indicating how long after the time the dose is due for the reminder to be sent.
+      indicating how long after the time the dose is due for the reminder to be sent. Separate each
+      interval with a semicolon.
     {/snippet}
 
     <InputDays


### PR DESCRIPTION
Makes the InputDays component work without an `initial` parameter, e.g. in this case where there is no dosage currently set up. Also makes the placeholder actually work for it
Additionally adds the important info to the reminder recurrence description that each interval in the list is separated with a semicolon, which is unclear to the user otherwise